### PR TITLE
small formatting updates, w/ backwards compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
-  - "iojs-v1.8"
-  - "iojs-v2.2"
+  - "0"
+  - "4"
+  - "5"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ MaxCDN API for Node.js
 
 [![Build Status](https://travis-ci.org/MaxCDN/node-maxcdn.png?branch=master)](https://travis-ci.org/MaxCDN/node-maxcdn) &nbsp; [![Dependancy Status](https://david-dm.org/MaxCDN/node-maxcdn.png)](https://david-dm.org/MaxCDN/node-maxcdn) &nbsp; [![NPM Version](https://badge.fury.io/js/maxcdn.png)](https://badge.fury.io/js/maxcdn) &nbsp;  <iframe src="http://jmervine.github.io/npm-downloads-badge/badge.html?module=maxcdn&name=false" allowtransparency="true" frameborder="0" scrolling="0" width="125" height="20" style="vertical-align: bottom"></iframe>
 
-> Note: Unit tests have been run agaist both Node.js v0.12.0 and io.js v1.1.0, in addtion to standard Node.js 0.10.x version, all passed.
+> Note: Unit tests have been run agaist latest 4.x and 5.x versions of Node.js.
 
 ## Install
 
@@ -17,8 +17,7 @@ $ npm install maxcdn
 #### Initialize
 
 ```
-var MaxCDN = require('maxcdn');
-var maxcdn = new MaxCDN('COMPANY_ALIAS', 'CONSUMER_KEY', 'CONSUMER_SECRET');
+var maxcdn = require('maxcdn').create('COMPANY_ALIAS', 'CONSUMER_KEY', 'CONSUMER_SECRET');
 ```
 
 #### `maxcdn.get`

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 var OAuth       = require('oauth').OAuth;
 var querystring = require('querystring');
 
+function create(alias, key, secret) {
+    return new MaxCDN(alias, key, secret);
+}
+
 function MaxCDN(alias, key, secret) {
     if (typeof alias !== 'string') {
         throw new Error('company alias missing or not a string');
@@ -125,4 +129,5 @@ MaxCDN.prototype._parse = function _parse(callback) {
 };
 
 module.exports = MaxCDN;
+module.exports.create = create;
 // vim: ft=javascript ai sw=4 sts=4 et:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maxcdn",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "MaxCDN API for Node.js",
   "main": "index.js",
   "scripts": {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -18,9 +18,24 @@ OAuth.prototype.put    = oaStub;
 OAuth.prototype.post   = oaStub;
 OAuth.prototype.delete = oaStub;
 
-var MaxCDN = require('../index');
+test('maxcdn.create', function(t) {
+    var maxcdn = require('../index');
 
-test('maxcdn', function(t) {
+    // setup
+    t.throws(function() {
+        maxcdn.create();
+    });
+
+    t.doesNotThrow(function() {
+        maxcdn.create('alias', 'key', 'secret');
+    });
+
+    t.end();
+});
+
+test('MaxCDN', function(t) {
+    var MaxCDN = require('../index');
+
     // setup
     t.throws(function() {
         new MaxCDN();


### PR DESCRIPTION
@jdorfman here's the changes I was talking about to make this initialized a little more like modern node, it's trivial

changes:

- [x] support `require('maxcdn').create( ... args ...)`
- [x] add latest versions of node to travis
- [x] bump version

Note: this will require a tag and npm release for version `0.2.0` once merged