### PR TITLE
Fix PUT method not including its arguments in signature base

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ MaxCDN.prototype.get = function get(url, callback) {
 };
 
 MaxCDN.prototype.put = function put(url, data, callback) {
-    this.oauth.put(this._makeUrl(url), '', '', this._makeQuerystring(data), this._parse(callback));
+    this.oauth.put(this._makeUrl(url), '', '', this._makeObject(data), this._parse(callback));
 };
 
 MaxCDN.prototype.post = function post(url, data, callback) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -91,7 +91,7 @@ test('MaxCDN', function(t) {
         t.error(err, 'put w/o error');
         t.equal(data.foo, 'bar', 'put w/ data');
         t.equal(data.arguments[0], 'https://rws.maxcdn.com/alias/path', 'put w/ path');
-        t.deepEqual(data.arguments[3], 'data=data', 'put sends data');
+        t.deepEqual(data.arguments[3], { data: 'data' }, 'put sends data');
     });
 
     // post


### PR DESCRIPTION
This will fix "invalid signature" error for all PUT requests that recently started to fail. The reason is quite possibly server-side update of the OAuth library. Old implementation didn't include form parameters in the signature when the method was PUT. Now I guess the API endpoint is updated to OAuth v1.0a spec.